### PR TITLE
Add pyrtma logging messages to rtma-js

### DIFF
--- a/src/rtma.js
+++ b/src/rtma.js
@@ -409,7 +409,7 @@ export class RTMAClient {
     msg.time = Date.now()/1000;
     msg.level = 50;
     msg.name = this.module_id.toString();
-    msg.msg = msg_text;
+    msg.message = msg_text;
     
     console.error("CRITICAL: " + msg_text);
 
@@ -421,7 +421,7 @@ export class RTMAClient {
     msg.time = Date.now()/1000;
     msg.level = 40;
     msg.name = this.module_id.toString();
-    msg.msg = msg_text;
+    msg.message = msg_text;
     
     console.error("ERROR: " + msg_text);
 
@@ -433,9 +433,9 @@ export class RTMAClient {
     msg.time = Date.now()/1000;
     msg.level = 30;
     msg.name = this.module_id.toString();
-    msg.msg = msg_text;
+    msg.message = msg_text;
     
-    console.error("WARNING: " + msg_text);
+    console.warn("WARNING: " + msg_text);
 
     this.send_message(CORE.MT.RTMA_LOG_WARNING, msg);
   }
@@ -445,9 +445,9 @@ export class RTMAClient {
     msg.time = Date.now()/1000;
     msg.level = 20;
     msg.name = this.module_id.toString();
-    msg.msg = msg;
+    msg.message = msg_text;
     
-    console.error("INFO: " + msg_text);
+    console.log("INFO: " + msg_text);
 
     this.send_message(CORE.MT.RTMA_LOG_INFO, msg);
   }
@@ -457,21 +457,24 @@ export class RTMAClient {
     msg.time = Date.now()/1000;
     msg.level = 10;
     msg.name = this.module_id.toString();
-    msg.msg = msg_text;
+    msg.message = msg_text;
     
-    console.error("DEBUG: " + msg_text);
+    console.debug("DEBUG: " + msg_text);
 
     this.send_message(CORE.MT.RTMA_LOG_DEBUG, msg);
   }
 
-  log(msg_text, level = 10) {
+  log(msg_text, level = 0) {
     const msg = CORE.MDF.RTMA_LOG();
     msg.time = Date.now()/1000;
     msg.level = level;
     msg.name = this.module_id.toString();
-    msg.msg = msg_text;
+    msg.message = msg_text;
     
-    console.error("LOG: " + msg_text);
+    if (level < 20) { console.debug("LOG: " + msg_text); }
+    else if (level < 30) { console.log("LOG: " + msg_text); }
+    else if (level < 40) { console.warn("LOG: " + msg_text); }
+    else { console.error("LOG: " + msg_text); }
 
     this.send_message(CORE.MT.RTMA_LOG, msg);
   }

--- a/src/rtma.js
+++ b/src/rtma.js
@@ -183,6 +183,7 @@ export class RTMAClient {
     this.pending_ack = false;
     this.ws = null;
     this.connect_ack = false;
+    this.subscribed_types = Set([]);
 
     this.on_connect = () => {};
 
@@ -285,6 +286,7 @@ export class RTMAClient {
       console.log(`rtma.js: Subscribing to ${msg_type}`);
       this.send_message(CORE.MT.SUBSCRIBE, msg);
     });
+    this.subscribed_types.union(Set(msg_types));
   }
 
   unsubscribe(msg_types) {
@@ -294,6 +296,7 @@ export class RTMAClient {
       console.log(`rtma.js: Unsubscribing to ${msg_type}`);
       this.send_message(CORE.MT.UNSUBSCRIBE, msg);
     });
+    this.subscribed_types.difference(Set(msg_types));
   }
 
   error_handler(msg) {

--- a/src/rtma.js
+++ b/src/rtma.js
@@ -31,6 +31,12 @@ const CORE = {
     MODULE_READY: 26,
     SAVE_MESSAGE_LOG: 56,
     TIMING_MESSAGE: 80,
+    RTMA_LOG: 40,
+    RTMA_LOG_CRITICAL: 41,
+    RTMA_LOG_ERROR: 42,
+    RTMA_LOG_WARNING: 43,
+    RTMA_LOG_INFO: 44,
+    RTMA_LOG_DEBUG: 45
   },
 
   MID: {
@@ -145,6 +151,78 @@ const CORE = {
         timing: Array(MAX_MESSAGE_TYPES).fill(0),
         ModulePID: Array(MAX_MODULES).fill(0),
         send_time: 0,
+      };
+    },
+
+    RTMA_LOG: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
+      };
+    },
+
+    RTMA_LOG_CRITICAL: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
+      };
+    },
+
+    RTMA_LOG_ERROR: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
+      };
+    },
+
+    RTMA_LOG_WARNING: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
+      };
+    },
+
+    RTMA_LOG_INFO: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
+      };
+    },
+
+    RTMA_LOG_DEBUG: () => {
+      return {
+        time: 0,
+        level: 0,
+        lineno: 0,
+        name: "", 
+        pathname: "",
+        funcname: "",
+        message: "",
       };
     },
 
@@ -321,6 +399,78 @@ export class RTMAClient {
       default:
         break;
     }
+  }
+
+  log_critical(msg_text) {
+    const msg = CORE.MDF.RTMA_LOG_CRITICAL();
+    msg.time = Date.now()/1000;
+    msg.level = 50;
+    msg.name = this.module_id.toString();
+    msg.msg = msg_text;
+    
+    console.error("CRITICAL: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG_CRITICAL, msg);
+  }
+
+  log_error(msg_text) {
+    const msg = CORE.MDF.RTMA_LOG_ERROR();
+    msg.time = Date.now()/1000;
+    msg.level = 40;
+    msg.name = this.module_id.toString();
+    msg.msg = msg_text;
+    
+    console.error("ERROR: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG_ERROR, msg);
+  }
+
+  log_warning(msg_text) {
+    const msg = CORE.MDF.RTMA_LOG_WARNING();
+    msg.time = Date.now()/1000;
+    msg.level = 30;
+    msg.name = this.module_id.toString();
+    msg.msg = msg_text;
+    
+    console.error("WARNING: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG_WARNING, msg);
+  }
+
+  log_info(msg_text) {
+    const msg = CORE.MDF.RTMA_LOG_INFO();
+    msg.time = Date.now()/1000;
+    msg.level = 20;
+    msg.name = this.module_id.toString();
+    msg.msg = msg;
+    
+    console.error("INFO: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG_INFO, msg);
+  }
+
+  log_debug(msg_text) {
+    const msg = CORE.MDF.RTMA_LOG_DEBUG();
+    msg.time = Date.now()/1000;
+    msg.level = 10;
+    msg.name = this.module_id.toString();
+    msg.msg = msg_text;
+    
+    console.error("DEBUG: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG_DEBUG, msg);
+  }
+
+  log(msg_text, level = 10) {
+    const msg = CORE.MDF.RTMA_LOG();
+    msg.time = Date.now()/1000;
+    msg.level = level;
+    msg.name = this.module_id.toString();
+    msg.msg = msg_text;
+    
+    console.error("LOG: " + msg_text);
+
+    this.send_message(CORE.MT.RTMA_LOG, msg);
   }
 
   connect() {

--- a/src/rtma.js
+++ b/src/rtma.js
@@ -261,7 +261,7 @@ export class RTMAClient {
     this.pending_ack = false;
     this.ws = null;
     this.connect_ack = false;
-    this.subscribed_types = Set([]);
+    this.subscribed_types = new Set([]);
 
     this.on_connect = () => {};
 
@@ -364,7 +364,7 @@ export class RTMAClient {
       console.log(`rtma.js: Subscribing to ${msg_type}`);
       this.send_message(CORE.MT.SUBSCRIBE, msg);
     });
-    this.subscribed_types.union(Set(msg_types));
+    this.subscribed_types.union(new Set(msg_types));
   }
 
   unsubscribe(msg_types) {
@@ -374,7 +374,7 @@ export class RTMAClient {
       console.log(`rtma.js: Unsubscribing to ${msg_type}`);
       this.send_message(CORE.MT.UNSUBSCRIBE, msg);
     });
-    this.subscribed_types.difference(Set(msg_types));
+    this.subscribed_types.difference(new Set(msg_types));
   }
 
   error_handler(msg) {


### PR DESCRIPTION
These changes include the core definitions for pyrtma logging, as well as functions which allow the client to send these logs while displaying an accompanying javascript log in the javascript console. This also includes a new subscribed_types set added to the RTMAClient task, which adds and removes messages as they are subscribed to and unsubscribed from.